### PR TITLE
fix: handle relative paths in queryAdapter

### DIFF
--- a/packages/core/lib/adapters/query-adapter.ts
+++ b/packages/core/lib/adapters/query-adapter.ts
@@ -1,14 +1,56 @@
-import type { History } from 'history';
-import type { RouterAdapter, To } from './types';
+import { createPath, parsePath, type History } from 'history';
+import type { RouterAdapter, RouterLocation, To } from './types';
 
-function extractLocation(location: History['location']) {
-  const url = new URL(decodeURIComponent(location.search));
+function emptyLocation(): RouterLocation {
+  return {
+    pathname: '/',
+    search: '',
+    hash: '',
+  };
+}
+
+function extractLocation(location: History['location']): RouterLocation {
+  if (!location.search || location.search === '?') {
+    return emptyLocation();
+  }
+
+  const search = location.search.startsWith('?')
+    ? location.search.slice(1)
+    : location.search;
+
+  if (!search) {
+    return emptyLocation();
+  }
+
+  const {
+    pathname,
+    search: nestedSearch,
+    hash,
+  } = parsePath(decodeURIComponent(search));
 
   return {
-    pathname: url.pathname,
-    search: url.search,
-    hash: url.hash,
+    pathname: pathname ?? '/',
+    search: nestedSearch ?? '',
+    hash: hash ?? '',
   };
+}
+
+function stringifyTo(to: To): string {
+  if (typeof to === 'string') {
+    return to;
+  }
+
+  return createPath({
+    pathname: to.pathname ?? '/',
+    search: to.search ?? '',
+    hash: to.hash ?? '',
+  });
+}
+
+function createSearch(to: To): string {
+  const path = stringifyTo(to);
+
+  return path ? `?${encodeURIComponent(path)}` : '';
 }
 
 export function queryAdapter(history: History): RouterAdapter {
@@ -16,27 +58,19 @@ export function queryAdapter(history: History): RouterAdapter {
     location: extractLocation(history.location),
 
     push: (to: To) => {
-      if (typeof to === 'string') {
-        const url = new URL(history.location.pathname);
-        url.search = to;
-        history.push(url.toString());
-      } else {
-        const url = new URL(history.location.pathname);
-        url.search = `${to.pathname ?? ''}${to.search ?? ''}${to.hash ?? ''}`;
-        history.push(url.toString());
-      }
+      history.push({
+        pathname: history.location.pathname,
+        search: createSearch(to),
+        hash: history.location.hash,
+      });
     },
 
     replace: (to: To) => {
-      if (typeof to === 'string') {
-        const url = new URL(history.location.pathname);
-        url.search = to;
-        history.replace(url.toString());
-      } else {
-        const url = new URL(history.location.pathname);
-        url.search = `${to.pathname ?? ''}${to.search ?? ''}${to.hash ?? ''}`;
-        history.replace(url.toString());
-      }
+      history.replace({
+        pathname: history.location.pathname,
+        search: createSearch(to),
+        hash: history.location.hash,
+      });
     },
 
     goBack: () => {

--- a/packages/core/tests/query-adapter.test.ts
+++ b/packages/core/tests/query-adapter.test.ts
@@ -1,0 +1,48 @@
+import { createMemoryHistory } from 'history';
+import { describe, expect, test } from 'vitest';
+import { queryAdapter } from '../lib';
+
+describe('queryAdapter', () => {
+  test('does not throw on empty search', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/users'],
+    });
+
+    expect(() => queryAdapter(history)).not.toThrow();
+
+    expect(queryAdapter(history).location).toEqual({
+      pathname: '/',
+      search: '',
+      hash: '',
+    });
+  });
+
+  test('pushes route into current location search', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/users'],
+    });
+
+    const adapter = queryAdapter(history);
+
+    adapter.push({
+      pathname: '/user/1',
+    });
+
+    expect(history.location.pathname).toBe('/users');
+    expect(history.location.search).toBe('?%2Fuser%2F1');
+  });
+
+  test('extracts route from location search', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/users?%2Fuser%2F1'],
+    });
+
+    const adapter = queryAdapter(history);
+
+    expect(adapter.location).toEqual({
+      pathname: '/user/1',
+      search: '',
+      hash: '',
+    });
+  });
+});


### PR DESCRIPTION
Fixes #7.

`queryAdapter` currently passes relative history values to `new URL(...)`.

This can crash when:

- `location.search` is empty
- `location.pathname` is a relative path like `/users`

This PR replaces `new URL(...)` usage with `history` path helpers:

- `parsePath` for reading the nested route from search
- `createPath` for serializing router navigation targets

The public API is unchanged.

Tested with:

```sh
pnpm --filter @effector/router test
```